### PR TITLE
Adding versioning to Virtualbox

### DIFF
--- a/site/profile/manifests/default.pp
+++ b/site/profile/manifests/default.pp
@@ -175,7 +175,8 @@ class profile::default {
 	}
 	
 	service{ "puppet":
-		ensure => lookup("puppet_agent_service_state")
+		ensure => lookup("puppet_agent_service_state"),
+		enable => true,
 	}
 
 ################################################################################

--- a/site/profile/manifests/ts/ts_intcluster.pp
+++ b/site/profile/manifests/ts/ts_intcluster.pp
@@ -2,7 +2,8 @@ class profile::ts::ts_intcluster {
 	include profile::it::ssh_server
 	$kernel_devel = lookup("kernel_devel")
 	class {"virtualbox":
-		require => Package[$kernel_devel]
+		require => Package[$kernel_devel],
+		package_name => lookup("virtualbox_version"),
 	}
 
 	package{"vagrant":


### PR DESCRIPTION
Now you can handle and fix ts-intcluster to a particular virtual box version. Also enforced puppet to be enabled. You can decided whether this has to be stopped or not. 