### PR TITLE
Graylog and Ruby Libs

### DIFF
--- a/site/profile/manifests/it/graylog.pp
+++ b/site/profile/manifests/it/graylog.pp
@@ -44,13 +44,14 @@ class profile::it::graylog {
 		version => '2.4'
 	}
 
+	$graylog_url = lookup("graylog_url")
 	class { 'graylog::server':
 		package_version => '2.4.0-9',
 		config          => {
 			password_secret => lookup("graylog_server_password_secret"),    # Fill in your password secret, must have more than 16 characters
 			root_password_sha2 => lookup("graylog_server_root_password_sha2"), # Fill in your root password hash
-			web_listen_uri => "http://${ipaddress}:9000",
-			rest_listen_uri => "http://${ipaddress}:9000/api",
+			web_listen_uri => "http://${graylog_url}:9000",
+			rest_listen_uri => "http://${graylog_url}:9000/api",
 		}
 	}
 }

--- a/site/profile/manifests/it/puppet_master.pp
+++ b/site/profile/manifests/it/puppet_master.pp
@@ -66,6 +66,13 @@ class profile::it::puppet_master {
 		path => "/root/.bash_profile",
 	}
 
+	file_line{ "Update Ruby libs puppetserver configuration" :
+		ensure => present,
+		line => "    ruby-load-path: [/opt/puppetlabs/puppet/lib/ruby/vendor_ruby, /opt/puppetlabs/puppet/cache/lib]",
+		match => "ruby-load-path*",
+		path => "/etc/puppetlabs/puppetserver/conf.d/puppetserver.conf",
+	}
+
 	# Can be fixed once we manage to fix the issue with Hiera ssh key
 	#file{ "/root/.ssh":
 	#	ensure => directory,


### PR DESCRIPTION
I've updated the graylog url to be configured trough hiera by using graylog_url variable and also added an append on the puppetserver config file to use: 
`/opt/puppetlabs/puppet/cache/lib `

To load resources from elastic search stack. Tests done on the docker container environment and replicated with Vagrant to verify its complaint with other changes.