### PR TITLE
Improving cacert and keytool checks

### DIFF
--- a/site/profile/manifests/it/graylog.pp
+++ b/site/profile/manifests/it/graylog.pp
@@ -118,16 +118,7 @@ class profile::it::graylog {
 	
 	#Copy the current CA Cert into graylog's directory
 	
-	$graylog_cacert_filename = "graylog-cacerts"
-	/*
-	file{ "${ssl_config_dir}/${graylog_cacert_filename}" :
-		ensure => present,
-		links => follow,
-		source => "/etc/pki/java/cacerts",
-		require => File["${ssl_config_dir}"]
-	}
-	*/
-	
+	$graylog_cacert_filename = "graylog-cacerts"	
 	exec{ "Copy JAVA cacerts into graylog's directory":
 		path  => [ '/usr/bin', '/bin', '/usr/sbin' ],
 		command => "cp /etc/pki/java/cacerts ${ssl_config_dir}/${graylog_cacert_filename}",

--- a/site/profile/manifests/it/graylog.pp
+++ b/site/profile/manifests/it/graylog.pp
@@ -139,7 +139,7 @@ class profile::it::graylog {
 		path  => [ '/usr/bin', '/bin', '/usr/sbin' ],
 		command => "keytool -noprompt -importcert -keystore ${ssl_config_dir}/${graylog_cacert_filename} -storepass ${ssl_graylog_cert_pass} -alias graylog-self-signed -file ${ssl_config_dir}/${ssl_graylog_cert_filename}",
 		onlyif => "test -z $(keytool -keystore ${ssl_config_dir}/${graylog_cacert_filename} -storepass ${ssl_graylog_cert_pass} -list | grep graylog-self-signed)",
-		require => [Exec["Create graylog SSL key"], File["${ssl_config_dir}/${graylog_cacert_filename}"]]
+		require => [Exec["Create graylog SSL key"], Exec["Copy JAVA cacerts into graylog's directory"]]
 	}
 
 	# Setup Graylog server

--- a/site/profile/manifests/it/graylog.pp
+++ b/site/profile/manifests/it/graylog.pp
@@ -130,7 +130,7 @@ class profile::it::graylog {
 	exec{ "Update keytool" :
 		path  => [ '/usr/bin', '/bin', '/usr/sbin' ],
 		command => "keytool -noprompt -importcert -keystore ${ssl_config_dir}/${graylog_cacert_filename} -storepass ${ssl_graylog_cert_pass} -alias graylog-self-signed -file ${ssl_config_dir}/${ssl_graylog_cert_filename}",
-		onlyif => "test ! -f ${ssl_config_dir}/${graylog_cacert_filename}",
+		onlyif => "test -z $(keytool -keystore ${ssl_config_dir}/${graylog_cacert_filename} -storepass ${ssl_graylog_cert_pass} -list | grep graylog-self-signed)",
 		require => [Exec["Create graylog SSL key"], File["${ssl_config_dir}/${graylog_cacert_filename}"]]
 	}
 

--- a/site/profile/manifests/it/graylog.pp
+++ b/site/profile/manifests/it/graylog.pp
@@ -119,11 +119,19 @@ class profile::it::graylog {
 	#Copy the current CA Cert into graylog's directory
 	
 	$graylog_cacert_filename = "graylog-cacerts"
+	/*
 	file{ "${ssl_config_dir}/${graylog_cacert_filename}" :
 		ensure => present,
 		links => follow,
 		source => "/etc/pki/java/cacerts",
 		require => File["${ssl_config_dir}"]
+	}
+	*/
+	
+	exec{ "Copy JAVA cacerts into graylog's directory":
+		path  => [ '/usr/bin', '/bin', '/usr/sbin' ],
+		command => "cp /etc/pki/java/cacerts ${ssl_config_dir}/${graylog_cacert_filename}",
+		onlyif => "test ! -f ${ssl_config_dir}/${graylog_cacert_filename}"
 	}
 	
 	$ssl_graylog_cert_pass = lookup("ssl_graylog_cert_pass")


### PR DESCRIPTION
When rolling in this change from develop to production, I realized that the File resource doesn't have an onlyif statement, hence every time it was executed, the cacert file was overwriting the graylog-cacert file. So I'm replaced the File resource by an Exec which actually have a onlyif statement. Now the file is being copied only if graylog-cacert file doesn't exists.