### PR TITLE
Delete commented lines, added dnssearchdomains.

### DIFF
--- a/site/profile/manifests/it/gs_dhcp.pp
+++ b/site/profile/manifests/it/gs_dhcp.pp
@@ -1,18 +1,13 @@
 class profile::it::gs_dhcp{
 	class { 'dhcp':
 		service_ensure => running,
-		dnsdomain      => lookup("dnsdomains"),
+		dnsdomain      => lookup("dnsdomain"),
+		dnssearchdomains => lookup("dnssearchdomains"),
 		nameservers  => lookup("nameservers"),
 		ntpservers   => lookup("ntpservers"),
-		interfaces   => lookup("dhcp_interfaces"),
-		#dnsupdatekey => '/etc/bind/keys.d/rndc.key',
-		#dnskeyname   => 'rndc-key',
-		#require      => Bind::Key['rndc-key'],
-		#pxeserver    => '10.0.1.50',
-		#pxefilename  => 'pxelinux.0',
+		interfaces   => lookup("dhcp_interfaces"), # This interface is later configured in /etc/systemd/system/dhcpd.service
 		omapi_port   => 7911,
 		extra_config => [lookup("failover_configuration")],
-		#extra_config => ["dummy_config 1" , "dummy_config 2"],
 		dhcp_conf_extra => "INTERNAL_TEMPLATE",
 		pools => lookup("dhcp_pools"),
 		ignoredsubnets => lookup("ignored_subnets")


### PR DESCRIPTION
We've realized that DNS Search Domains were not properly offered to users when connecting, with this configuration, we are allowing that option in the DHCP server. This test was applied on November Monday 26 2018, no users' complains, internet and DHCP worked properly, therefore we are moving this change to the standard  configuration.